### PR TITLE
Create Stock, Stock Cache, Stock History cache, historical data for yahoo finance endpoints and seeding

### DIFF
--- a/backend/financeDb.sql
+++ b/backend/financeDb.sql
@@ -36,3 +36,25 @@ CREATE TABLE
         PRIMARY KEY (id),
         FOREIGN KEY (user_id) REFERENCES users (id)
     );
+
+CREATE TABLE
+    IF NOT EXISTS stock_cache (
+        symbol VARCHAR(10) NOT NULL,
+        current_price DECIMAL(10, 2),
+        open_price DECIMAL(10, 2),
+        high_price DECIMAL(10, 2),
+        low_price DECIMAL(10, 2),
+        updated_at DATETIME,
+        PRIMARY KEY (symbol)
+    );
+
+CREATE TABLE
+    IF NOT EXISTS stock_history_cache (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        symbol VARCHAR(10),
+        time_interval VARCHAR(20),
+        history_json LONGTEXT,
+        cached_at DATETIME,
+        expires_at DATETIME,
+        PRIMARY KEY (id)
+    );

--- a/backend/src/main/java/com/sakib_jeter/backend/controller/MarketController.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/controller/MarketController.java
@@ -1,29 +1,87 @@
 package com.sakib_jeter.backend.controller;
 
-import com.sakib_jeter.backend.service.MarketService;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sakib_jeter.backend.dto.Stock;
+import com.sakib_jeter.backend.entity.StockCache;
+import com.sakib_jeter.backend.external.FinnhubService;
+import com.sakib_jeter.backend.external.StockDataSeeder;
+import com.sakib_jeter.backend.external.YahooFinanceService;
+import com.sakib_jeter.backend.service.MarketService;
 
 @RestController
 @RequestMapping("/api/market")
 @CrossOrigin(origins = "http://localhost:4200")
 public class MarketController {
 
-    private final MarketService service;
+    private final MarketService marketService;
+    private final FinnhubService finnhubService;
+    private final YahooFinanceService yahooService;
+    private final StockDataSeeder stockDataSeeder;
 
-    public MarketController(MarketService service) {
-        this.service = service;
+    public MarketController(MarketService marketService,
+            FinnhubService finnhubService,
+            YahooFinanceService yahooService,
+            StockDataSeeder stockDataSeeder) {
+        this.marketService = marketService;
+        this.finnhubService = finnhubService;
+        this.yahooService = yahooService;
+        this.stockDataSeeder = stockDataSeeder;
     }
 
-    // ✅ QUOTE
-    @GetMapping("/{symbol}")
-    public ResponseEntity<?> getQuote(@PathVariable String symbol) {
-        return ResponseEntity.ok(service.getQuote(symbol));
+    // Ticker marquee — reads from cache only
+    @GetMapping("/ticker")
+    public List<Map<String, Object>> getTicker() {
+        return marketService.getMostActiveStocks();
     }
 
-    // 🔥 REAL-TIME CHART
-    @GetMapping("/chart/{symbol}")
-    public ResponseEntity<?> getChart(@PathVariable String symbol) {
-        return ResponseEntity.ok(service.getRealtimeChart(symbol));
+    // Symbol search via Finnhub
+    @GetMapping("/search")
+    public List<Map<String, Object>> search(@RequestParam String q) {
+        return finnhubService.searchSymbol(q);
+    }
+
+    // Historical candle data via Yahoo Finance
+    @GetMapping("/history/{symbol}")
+    public List<Stock> getHistory(@PathVariable String symbol) {
+        return yahooService.getHistory(symbol.toUpperCase());
+    }
+
+    // Seed live prices for all stocks via Finnhub
+    @GetMapping("/seed")
+    public String seed() {
+        new Thread(() -> stockDataSeeder.seedAll()).start();
+        return "Price seeding started in background";
+    }
+
+    // Seed yearly history for all stocks via Yahoo Finance
+    @GetMapping("/seed/history")
+    public String seedHistory() {
+        stockDataSeeder.seedHistory();
+        return "History seeding started in background";
+    }
+
+    // Returns all cached stocks — used by buy stock component
+    @GetMapping("/cached")
+    public List<StockCache> getCachedStocks() {
+        return marketService.getAllCachedStocks();
+    }
+
+    // Get single stock price from cache — MUST be last mapping
+    @GetMapping("/quote/{symbol}")
+    public ResponseEntity<StockCache> getStock(@PathVariable String symbol) {
+        StockCache stock = marketService.getOrFetch(symbol.toUpperCase());
+        return stock != null
+                ? ResponseEntity.ok(stock)
+                : ResponseEntity.notFound().build();
     }
 }

--- a/backend/src/main/java/com/sakib_jeter/backend/dto/Stock.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/dto/Stock.java
@@ -1,0 +1,18 @@
+package com.sakib_jeter.backend.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Stock {
+    private LocalDateTime date;
+    private double open;
+    private double high;
+    private double low;
+    private double close;
+}

--- a/backend/src/main/java/com/sakib_jeter/backend/entity/StockCache.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/entity/StockCache.java
@@ -1,0 +1,40 @@
+package com.sakib_jeter.backend.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Entity
+@Table(name = "stock_cache")
+@Data
+@AllArgsConstructor
+public class StockCache {
+    
+
+    @Id
+    private String symbol;
+
+    @Column(name = "current_price", precision = 10, scale = 2)
+    private BigDecimal currentPrice;
+
+    @Column(name = "open_price", precision = 10, scale = 2)
+    private BigDecimal openPrice;
+
+    @Column(name = "high_price", precision = 10, scale = 2)
+    private BigDecimal highPrice;
+
+    @Column(name = "low_price", precision = 10, scale = 2)
+    private BigDecimal lowPrice;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public StockCache() {
+    }
+}

--- a/backend/src/main/java/com/sakib_jeter/backend/entity/StockHistoryCache.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/entity/StockHistoryCache.java
@@ -1,0 +1,24 @@
+package com.sakib_jeter.backend.entity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "stock_history_cache")
+@Data @NoArgsConstructor @AllArgsConstructor
+public class StockHistoryCache {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String symbol;
+    @Column(name = "time_interval", nullable = false)
+    private String timeInterval;
+    @Column(columnDefinition = "LONGTEXT")
+    private String historyJson;
+    @Column(name = "cached_at")
+    private LocalDateTime cachedAt;
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+}

--- a/backend/src/main/java/com/sakib_jeter/backend/external/FinnhubService.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/external/FinnhubService.java
@@ -1,0 +1,63 @@
+package com.sakib_jeter.backend.external;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+// Direct Finnhub API calls — no caching
+// Used for: live price at sell time, symbol search
+// Docs: https://finnhub.io/docs/api
+@Service
+public class FinnhubService {
+
+    @Value("${finnhub.api.key}")
+    private String apiKey;
+
+    @Value("${finnhub.base.url}")
+    private String baseUrl;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // Called only at moment of sell — returns live current price
+    // Finnhub field: c = current price
+    public BigDecimal getLivePrice(String symbol) {
+        try {
+            Map<String, Object> r = restTemplate.getForObject(
+                    baseUrl + "/quote?symbol=" + symbol + "&token=" + apiKey, Map.class);
+            if (r == null)
+                throw new RuntimeException("No response from Finnhub");
+            return new BigDecimal(r.get("c").toString());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get live price for " + symbol + ": " + e.getMessage());
+        }
+    }
+
+    // Returns full quote — c, o, h, l, pc fields
+    public Map<String, Object> getFullQuote(String symbol) {
+        try {
+            return restTemplate.getForObject(
+                    baseUrl + "/quote?symbol=" + symbol + "&token=" + apiKey, Map.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get quote for " + symbol);
+        }
+    }
+
+    // Symbol search autocomplete — used in buy stock component
+    public List<Map<String, Object>> searchSymbol(String query) {
+        try {
+            Map<String, Object> r = restTemplate.getForObject(
+                    baseUrl + "/search?q=" + query + "&token=" + apiKey, Map.class);
+            if (r == null)
+                return new ArrayList<>();
+            return (List<Map<String, Object>>) r.get("result");
+        } catch (Exception e) {
+            System.err.println("Finnhub search failed: " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+}

--- a/backend/src/main/java/com/sakib_jeter/backend/external/StockDataSeeder.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/external/StockDataSeeder.java
@@ -1,0 +1,144 @@
+package com.sakib_jeter.backend.external;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.sakib_jeter.backend.entity.StockCache;
+import com.sakib_jeter.backend.repository.StockCacheRepository;
+
+// Seeds stock_cache and stock_history_cache tables
+// stock_cache         — live prices via Finnhub API (docs: https://finnhub.io/docs/api/quote)
+// stock_history_cache — 1 year daily OHLC data via Yahoo Finance
+@Service
+public class StockDataSeeder {
+
+    @Value("${finnhub.api.key}")
+    private String finnhubKey;
+
+    @Value("${finnhub.base.url}")
+    private String finnhubUrl;
+
+    private final StockCacheRepository stockCacheRepository;
+    private final YahooFinanceService yahooFinanceService;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // All symbols seeded into both tables
+    private static final String[] SYMBOLS = {
+            "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA", "ORCL",
+            "INTC", "AMD", "QCOM", "ADBE", "CRM", "NFLX", "UBER", "PYPL",
+            "CSCO", "IBM", "TXN", "AVGO", "MU", "AMAT",
+            "JPM", "BAC", "WFC", "GS", "MS", "C", "AXP", "V", "MA", "BLK",
+            "SCHW", "COF", "USB", "PNC", "AIG", "MET", "PRU",
+            "WMT", "TGT", "COST", "HD", "LOW", "MCD", "SBUX", "NKE", "DIS",
+            "EBAY", "ETSY", "BBY", "DG", "DLTR",
+            "JNJ", "PFE", "MRK", "ABBV", "UNH", "CVS", "BMY", "AMGN",
+            "GILD", "BIIB", "REGN", "VRTX", "ZTS", "MDT",
+            "XOM", "CVX", "COP", "EOG", "SLB", "HAL", "MPC", "VLO",
+            "SPY", "QQQ", "DIA", "IWM", "VTI", "VOO", "GLD",
+            "PLTR", "SNOW", "DDOG", "NET", "ZS", "CRWD", "OKTA", "PANW",
+            "SHOP", "SQ", "COIN", "SOFI", "AFRM", "ZM", "DOCU", "TWLO",
+            "MDB", "HUBS", "ABNB", "DASH", "LYFT", "RBLX",
+            "F", "GM", "RIVN", "NIO",
+            "BA", "RTX", "LMT", "NOC", "GD",
+            "GE", "HON", "MMM", "CAT", "DE",
+            "T", "VZ", "TMUS", "CMCSA",
+            "NEE", "DUK", "SO", "AEP",
+            "AMT", "PLD", "EQIX", "PSA", "O"
+    };
+
+    public StockDataSeeder(StockCacheRepository stockCacheRepository,
+            YahooFinanceService yahooFinanceService) {
+        this.stockCacheRepository = stockCacheRepository;
+        this.yahooFinanceService = yahooFinanceService;
+    }
+
+    // Seed live prices into stock_cache via Finnhub
+    // Free tier rate limit is 60 requests per minute so we sleep 1100ms between
+    // calls
+    public int seedAll() {
+        int count = 0;
+        for (String symbol : SYMBOLS) {
+            try {
+                StockCache stock = fetchQuote(symbol);
+                if (stock != null) {
+                    stockCacheRepository.save(stock);
+                    count++;
+                    System.out.println("Seeded: " + symbol + " @ $" + stock.getCurrentPrice());
+                }
+                Thread.sleep(1100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                System.err.println("Seed failed for " + symbol + ": " + e.getMessage());
+            }
+        }
+        return count;
+    }
+
+    // Seed yearly history into stock_history_cache via Yahoo Finance
+    // Runs in a background thread so it does not block HTTP requests
+    public void seedHistory() {
+        new Thread(() -> {
+            for (String symbol : SYMBOLS) {
+                try {
+                    yahooFinanceService.getHistory(symbol);
+                    System.out.println("History seeded: " + symbol);
+                    Thread.sleep(1000);
+                } catch (Exception e) {
+                    System.err.println("History seed failed for " + symbol + ": " + e.getMessage());
+                }
+            }
+            System.out.println("History seeding complete for " + SYMBOLS.length + " stocks");
+        }).start();
+    }
+
+    // Fetch a single quote from Finnhub
+    // Finnhub returns 0 for current price (c) when market is closed
+    // so we fall back to previous close (pc) in that case
+    public StockCache fetchQuote(String symbol) {
+        try {
+            String url = finnhubUrl + "/quote?symbol=" + symbol + "&token=" + finnhubKey;
+            Map<String, Object> r = restTemplate.getForObject(url, Map.class);
+            if (r == null)
+                return null;
+
+            BigDecimal current = toBD(r.get("c"));
+            BigDecimal prevClose = toBD(r.get("pc"));
+
+            // Fall back to previous close if market is closed
+            if (current.compareTo(BigDecimal.ZERO) == 0)
+                current = prevClose;
+            if (current.compareTo(BigDecimal.ZERO) == 0)
+                return null;
+
+            BigDecimal open = toBD(r.get("o"));
+            if (open.compareTo(BigDecimal.ZERO) == 0)
+                open = prevClose;
+
+            return new StockCache(symbol, current, open, toBD(r.get("h")), toBD(r.get("l")), LocalDateTime.now());
+
+        } catch (Exception e) {
+            System.err.println("Finnhub seed failed for " + symbol + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    // Safely convert Finnhub response value to BigDecimal
+    // Finnhub returns numbers as Double — BigDecimal is needed for financial
+    // precision
+    private BigDecimal toBD(Object v) {
+        if (v == null)
+            return BigDecimal.ZERO;
+        try {
+            return new BigDecimal(v.toString());
+        } catch (Exception e) {
+            return BigDecimal.ZERO;
+        }
+    }
+}

--- a/backend/src/main/java/com/sakib_jeter/backend/external/YahooFinanceService.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/external/YahooFinanceService.java
@@ -1,0 +1,169 @@
+package com.sakib_jeter.backend.external;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sakib_jeter.backend.dto.Stock;
+import com.sakib_jeter.backend.entity.StockHistoryCache;
+import com.sakib_jeter.backend.repository.StockHistoryCacheRepository;
+
+// Fetches 1 year of daily OHLC stock data from Yahoo Finance
+// No API key required
+// Caches results in stock_history_cache table for 240 minutes
+@Service
+public class YahooFinanceService {
+
+    // Injected from application.properties
+    @Value("${yahoo.base.url}")
+    private String baseUrl;
+
+    @Value("${yahoo.interval}")
+    private String interval;
+
+    private final StockHistoryCacheRepository repo;
+    private final RestTemplate rest = new RestTemplate();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public YahooFinanceService(StockHistoryCacheRepository repo) {
+        this.repo = repo;
+    }
+
+    // Public method called by controller and seeder
+    // Returns cached data if fresh, otherwise fetches from Yahoo
+    public List<Stock> getHistory(String symbol) {
+        return repo.findBySymbolAndTimeInterval(symbol, interval)
+                .filter(c -> c.getExpiresAt().isAfter(LocalDateTime.now())) // check if cache is still valid
+                .map(this::fromCache) // return from cache if valid
+                .orElseGet(() -> fetchAndSave(symbol)); // otherwise fetch from Yahoo
+    }
+
+    // Deserialize the JSON string stored in the database back into a list of Stock
+    // objects
+    private List<Stock> fromCache(StockHistoryCache c) {
+        try {
+            return Arrays.asList(mapper.readValue(c.getHistoryJson(), Stock[].class));
+        } catch (Exception e) {
+            System.err.println("Cache parse error: " + e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    // Fetch from Yahoo and save to cache before returning
+    private List<Stock> fetchAndSave(String symbol) {
+        List<Stock> data = fetch(symbol);
+        if (!data.isEmpty())
+            save(symbol, data);
+        return data;
+    }
+
+    // Call Yahoo Finance API and parse the response
+    // Yahoo response structure: chart -> result[0] -> timestamp + indicators ->
+    // quote[0] -> ohlc
+    private List<Stock> fetch(String symbol) {
+        try {
+            String url = baseUrl + "/" + symbol + "?interval=1d&range=1y";
+
+            // Browser-like User-Agent header required to avoid Yahoo 429 rate limiting
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("User-Agent", "Mozilla/5.0");
+
+            Map body = rest.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), Map.class).getBody();
+            if (body == null)
+                return List.of();
+
+            // Navigate the nested Yahoo response
+            Map chart = (Map) body.get("chart");
+            List result = (List) chart.get("result");
+            if (result == null || result.isEmpty())
+                return List.of();
+
+            Map data = (Map) result.get(0);
+
+            // Timestamps are Unix epoch seconds
+            List<Number> timestamps = (List<Number>) data.get("timestamp");
+
+            // OHLC prices are nested under indicators -> quote -> first element
+            Map indicators = (Map) data.get("indicators");
+            Map prices = (Map) ((List) indicators.get("quote")).get(0);
+
+            return buildStocks(timestamps, prices);
+
+        } catch (Exception e) {
+            System.err.println("Yahoo fetch failed: " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    // Convert raw timestamp and price arrays into a list of Stock DTOs
+    private List<Stock> buildStocks(List<Number> timestamps, Map prices) {
+        if (timestamps == null)
+            return List.of();
+
+        List<Number> opens = (List<Number>) prices.get("open");
+        List<Number> highs = (List<Number>) prices.get("high");
+        List<Number> lows = (List<Number>) prices.get("low");
+        List<Number> closes = (List<Number>) prices.get("close");
+
+        List<Stock> stocks = new ArrayList<>();
+        for (int i = 0; i < timestamps.size(); i++) {
+            if (closes.get(i) == null)
+                continue; // skip missing data points
+
+            // Convert Unix epoch seconds to LocalDateTime
+            LocalDateTime date = LocalDateTime.ofInstant(
+                    Instant.ofEpochSecond(timestamps.get(i).longValue()),
+                    ZoneId.systemDefault());
+
+            double close = closes.get(i).doubleValue();
+
+            stocks.add(new Stock(
+                    date,
+                    safeGet(opens, i, close),
+                    safeGet(highs, i, close),
+                    safeGet(lows, i, close),
+                    close));
+        }
+
+        return stocks;
+    }
+
+    // Safely get a value from a list — falls back to close price if null
+    private double safeGet(List<Number> list, int i, double fallback) {
+        return list != null && list.get(i) != null ? list.get(i).doubleValue() : fallback;
+    }
+
+    // Serialize Stock list to JSON and save to stock_history_cache table
+    private void save(String symbol, List<Stock> data) {
+        try {
+            // Reuse existing cache entry if present, otherwise create new one
+            StockHistoryCache entry = repo
+                    .findBySymbolAndTimeInterval(symbol, interval)
+                    .orElse(new StockHistoryCache());
+
+            LocalDateTime now = LocalDateTime.now();
+            entry.setSymbol(symbol);
+            entry.setTimeInterval(interval);
+            entry.setHistoryJson(mapper.writeValueAsString(data));
+            entry.setCachedAt(now);
+            entry.setExpiresAt(now.plusMinutes(240));
+            repo.save(entry);
+
+        } catch (Exception e) {
+            System.err.println("Cache save failed: " + e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/sakib_jeter/backend/repository/StockCacheRepository.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/repository/StockCacheRepository.java
@@ -1,0 +1,8 @@
+package com.sakib_jeter.backend.repository;
+
+import com.sakib_jeter.backend.entity.StockCache;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockCacheRepository extends JpaRepository<StockCache, String> {
+    // findById(symbol) inherited from JpaRepository
+}

--- a/backend/src/main/java/com/sakib_jeter/backend/repository/StockHistoryCacheRepository.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/repository/StockHistoryCacheRepository.java
@@ -1,0 +1,8 @@
+package com.sakib_jeter.backend.repository;
+import com.sakib_jeter.backend.entity.StockHistoryCache;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface StockHistoryCacheRepository extends JpaRepository<StockHistoryCache, Long> {
+    Optional<StockHistoryCache> findBySymbolAndTimeInterval(String symbol, String timeInterval);
+}

--- a/backend/src/main/java/com/sakib_jeter/backend/service/MarketService.java
+++ b/backend/src/main/java/com/sakib_jeter/backend/service/MarketService.java
@@ -1,67 +1,69 @@
 package com.sakib_jeter.backend.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import java.util.*;
+import org.springframework.stereotype.Service;
+
+import com.sakib_jeter.backend.entity.StockCache;
+import com.sakib_jeter.backend.repository.StockCacheRepository;
 
 @Service
 public class MarketService {
 
-    private final String FINNHUB_KEY = "d6tbgghr01qhkb43ge2gd6tbgghr01qhkb43ge30";
+    private final StockCacheRepository stockCacheRepository;
 
-    // 🔥 REAL-TIME STORAGE
-    private final Map<String, List<Double>> priceHistory = new HashMap<>();
-    private final Map<String, List<Long>> timeHistory = new HashMap<>();
+    // Stocks shown in the ticker
+    private static final String[] TICKER_SYMBOLS = {
+            "AAPL", "AMZN", "GOOGL", "JPM", "META", "MSFT", "NVDA", "TSLA", "V", "WMT"
+    };
 
-    // ✅ QUOTE (unchanged)
-    public Map<String, Object> getQuote(String symbol) {
-        RestTemplate restTemplate = new RestTemplate();
-
-        String url = "https://finnhub.io/api/v1/quote?symbol=" + symbol + "&token=" + FINNHUB_KEY;
-
-        try {
-            return restTemplate.getForObject(url, Map.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return Map.of("error", "quote_failed");
-        }
+    public MarketService(StockCacheRepository stockCacheRepository) {
+        this.stockCacheRepository = stockCacheRepository;
     }
 
-    // 🔥 REAL-TIME CHART (QUOTE-BASED)
-    public Map<String, Object> getRealtimeChart(String symbol) {
+    // Read from cache only — cache is populated by the seed endpoint
+    public StockCache getOrFetch(String symbol) {
+        return stockCacheRepository.findById(symbol).orElse(null);
+    }
 
-        Map<String, Object> quote = getQuote(symbol);
+    // Returns all cached stocks — used by buy stock search dropdown
+    public List<StockCache> getAllCachedStocks() {
+        return stockCacheRepository.findAll();
+    }
 
-        if (quote == null || quote.get("c") == null) {
-            return Map.of("s", "error");
+    // Ticker data — reads from cache only, never calls Finnhub
+    public List<Map<String, Object>> getMostActiveStocks() {
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (String symbol : TICKER_SYMBOLS) {
+            Optional<StockCache> cached = stockCacheRepository.findById(symbol);
+            if (cached.isPresent()) {
+                result.add(buildTicker(cached.get()));
+            }
         }
+        return result;
+    }
 
-        double currentPrice = ((Number) quote.get("c")).doubleValue();
-        long now = System.currentTimeMillis();
+    // Build ticker map from stock cache entry
+    private Map<String, Object> buildTicker(StockCache stock) {
+        BigDecimal current = stock.getCurrentPrice();
+        BigDecimal open = stock.getOpenPrice() != null ? stock.getOpenPrice() : current;
+        BigDecimal change = current.subtract(open);
+        BigDecimal pct = open.signum() != 0
+                ? change.divide(open, 2, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100))
+                : BigDecimal.ZERO;
 
-        priceHistory.putIfAbsent(symbol, new ArrayList<>());
-        timeHistory.putIfAbsent(symbol, new ArrayList<>());
-
-        List<Double> prices = priceHistory.get(symbol);
-        List<Long> times = timeHistory.get(symbol);
-
-        // 🔥 avoid duplicate spam (only every ~10s)
-        if (times.isEmpty() || now - times.get(times.size() - 1) > 9000) {
-            prices.add(currentPrice);
-            times.add(now);
-        }
-
-        // 🔥 keep last 100 points max
-        if (prices.size() > 100) {
-            prices.remove(0);
-            times.remove(0);
-        }
-
-        return Map.of(
-                "s", "ok",
-                "c", prices,
-                "t", times
-        );
+        Map<String, Object> ticker = new HashMap<>();
+        ticker.put("symbol", stock.getSymbol());
+        ticker.put("name", stock.getSymbol());
+        ticker.put("price", current);
+        ticker.put("change", change);
+        ticker.put("changesPercentage", pct);
+        return ticker;
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,10 +7,15 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
+
+finnhub.api.key=d6r24g1r01qgdhqcsf8gd6r24g1r01qgdhqcsf90
+finnhub.base.url=https://finnhub.io/api/v1
 
 server.port=8080
 
 springdoc.swagger-ui.path=/docs
 springdoc.api-docs.path=/v3/api-docs
 
+yahoo.base.url=https://query1.finance.yahoo.com/v8/finance/chart
+yahoo.interval=1year

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,7 +13,8 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "ES2022",
-    "module": "preserve"
+    "module": "preserve",
+    "moduleResolution": "bundler"
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
- Add finnhub.api.key and finnhub.base.url to application.properties
- Add yahoo.base.url and yahoo.interval to application.properties
- Add StockCache entity and SQL schema for stock_cache table
- Add StockHistoryCache entity and SQL schema for stock_history_cache table
- Add StockCacheRepository and StockHistoryCacheRepository
- Add Stock DTO for data returned by Yahoo Finance
- Add YahooFinanceService to fetch and cache 1 year of daily price history
- Add StockDataSeeder to seed stock_cache via Finnhub and stock_history_cache via Yahoo
- Add MarketService to read from stock_cache — no direct Finnhub calls
- Add FinnhubService to handle live price at sell time and symbol search only
- Update MarketController with ticker, search, history, quote, cached, seed endpoints

solves:

- #30 
- #38
- #39
- #37
- #31 
- #32 
- #33
- #34